### PR TITLE
Fix(travis): node v8 so new semantic-release succeeds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - "5.1"
+  - "8"
 env:
   - CXX=g++-4.8
 addons:


### PR DESCRIPTION
Newest semantic release reports node v8 as a requirement.

@jourdain Take a look at https://travis-ci.org/Kitware/kw-web-suite/builds/286211145
node v8 requirement seems to work